### PR TITLE
Support zsh on osx

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -1,7 +1,7 @@
 wget -O ~/.vocab "http://bit.ly/1WinY8l"
 if [[ "$OSTYPE" == "linux-gnu" && $(echo $0) == "bash" ]]; then
 	OSBASHRC=bashrc
-elif [[ "$OSTYPE" == "linux-gnu" && $(echo $0 == "zsh") ]]; then
+elif [[ $(echo $0 == "zsh") ]]; then
 	OSBASHRC=zshrc
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   OSBASHRC=bash_profile


### PR DESCRIPTION
$OSTYPE check prevents this script from working on zsh in osx.
